### PR TITLE
Aid Promise subclassability by avoiding Promise.resolve in #finally.

### DIFF
--- a/packages/promise/common.js
+++ b/packages/promise/common.js
@@ -1,4 +1,5 @@
 var global = this;
+var hasOwn = Object.prototype.hasOwnProperty;
 
 if (typeof global.Promise === "function") {
   exports.Promise = global.Promise;
@@ -7,7 +8,9 @@ if (typeof global.Promise === "function") {
     require("promise/lib/es6-extensions");
 }
 
-exports.Promise.prototype.done = function (onFulfilled, onRejected) {
+var proto = exports.Promise.prototype;
+
+proto.done = function (onFulfilled, onRejected) {
   var self = this;
 
   if (arguments.length > 0) {
@@ -21,16 +24,27 @@ exports.Promise.prototype.done = function (onFulfilled, onRejected) {
   });
 };
 
-if (! exports.Promise.prototype.hasOwnProperty("finally")) {
-  exports.Promise.prototype.finally = function (f) {
+if (! hasOwn.call(proto, "finally")) {
+  proto["finally"] = function (onFinally) {
+    var threw = false, result;
     return this.then(function (value) {
-      return exports.Promise.resolve(f()).then(function () {
-        return value;
-      });
-    }, function (err) {
-      return exports.Promise.resolve(f()).then(function () {
-        throw err;
-      });
+      result = value;
+      // Most implementations of Promise.prototype.finally call
+      // Promise.resolve(onFinally()) (or this.constructor.resolve or even
+      // this.constructor[Symbol.species].resolve, depending on how spec
+      // compliant they're trying to be), but this implementation simply
+      // relies on the standard Promise behavior of resolving any value
+      // returned from a .then callback function.
+      return onFinally();
+    }, function (error) {
+      // Make the final .then callback (below) re-throw the error instead
+      // of returning it.
+      threw = true;
+      result = error;
+      return onFinally();
+    }).then(function () {
+      if (threw) throw result;
+      return result;
     });
   };
 }


### PR DESCRIPTION
In order to be tolerant of `Promise` subclassing, polyfill implementations of `Promise.prototype.finally` typically implement logic to obtain the species constructor `C`, which is then used to call `C.resolve(onFinally())` or `new C(resolve => resolve(onFinally())` to ensure the resolved promise is `instanceof` the custom subclass.

However, a polyfill implementation of `Promise.prototype.finally` that does not need to call `resolve` explicitly could potentially avoid this extra effort to obtain the appropriate species constructor. If this new implementation is truly equivalent, then spec-compliant polyfills would no longer incur a penalty for following the spec exactly, compared to naive implementations that ignore these details for the sake of simplicity.

This pull request demonstrates one such implementation. Here's the essential logic:

```js
var threw = false;
var result;
return Promise.prototype.then.call(
  this,
  function (value) {
    result = value;
    return onFinally();
  },
  function (error) {
    threw = true;
    result = error;
    return onFinally();
  }
).then(function () {
  if (threw) throw result;
  return result;
});
```

The trick is to return the result of `onFinally()` from the `.then` callback functions, which automatically resolves the return value to an instance of the current `Promise` subclass, using whatever resolution logic the subclass implements. The final `.then` will be invoked against an instance of the subclass, allowing the subclass to define the behavior of `.then` and thus the final result of the `.finally` method.

Note that a spec-compliant implementation of `Promise.prototype.then` will almost certainly still need to obtain the species constructor in its own implementation. However, it seems desirable to keep that logic out of `Promise.prototype.finally` if possible.